### PR TITLE
Add option to select the data WorkingDir in Estimate_weights.py

### DIFF
--- a/Estimate_weights.py
+++ b/Estimate_weights.py
@@ -1,10 +1,25 @@
+import argparse
 import os, sys, csv, datetime, glob
 import numpy as np
 import matplotlib.pyplot as plt
 import datetime as dt
 import matplotlib.dates as mdates
 
-WorkingDir = '/media/julien/eSATA1/Julien/Marine plastics/Balnakeil Bin/Data'
+
+parser = argparse.ArgumentParser('Data Directory for parsing',
+	formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+parser.add_argument( '--datadir', required=False)
+
+args = parser.parse_args(sys.argv[1:])
+if args.datadir:
+	# python WorkingFileForTesting.py --datafile data/dbf900.ebc
+	WorkingDir = args.datadir
+else:
+	## Default local storage location
+	WorkingDir = r'/media/julien/eSATA1/Julien/Marine plastics/Balnakeil Bin/Data'
+
+
 FileList = sorted(glob.glob(WorkingDir+os.sep+'*.txt'))
 
 #d= {}


### PR DESCRIPTION
#### Description:
This pull-request adds the standard argparse module to Estimate_weights.py to enable data WorkingDir  to be input from the command line by adding the `--datadir` flag.  If the flag is not used then the original default data WorkingDir  will be used: ` 

#### Examples:
1.  Use the default WorkingDir.  If the default directory doesn't exist on the local machine, then nothing is displayed.
`python Estimate_weights.py`

2. Use a different WorkingDir, in this example it is 'Data'.
```
python Estimate_weights --datadir Data
192     7.389909544631639       0.31289832248708904 
166     6.389192627129438       0.27052667465029573 
...
```

3. Display argparse's help
```
python Estimate_weights.py --help
usage: Data Directory for parsing [-h] [--datadir DATADIR]

optional arguments:
  -h, --help         show this help message and exit
  --datadir DATADIR
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC