### PR TITLE
Update data paths for Weight scripts

### DIFF
--- a/WeightPlot.py
+++ b/WeightPlot.py
@@ -17,7 +17,8 @@ def butter_lowpass_filtfilt(data, cutoff, fs, order=5):
     y = filtfilt(b, a, data)
     return y
 
-WorkingDir = '/media/julien/eSATA1/Julien/Marine plastics/Balnakeil Bin/Weight'
+# Data directory: MarinePlasticTools/Weight
+WorkingDir = 'Weight'
 File = 'Weight_Data.txt'
 
 DATA  = np.genfromtxt(WorkingDir+os.sep+File, dtype=[('Date','datetime64[D]'),('Weight', 'float32'), ('Deviation', 'float32')], delimiter ='\t', skip_header = 1)

--- a/WeightPlot_BCG.py
+++ b/WeightPlot_BCG.py
@@ -17,7 +17,9 @@ def butter_lowpass_filtfilt(data, cutoff, fs, order=5):
     return y
 
 
-WorkingDir = os.getcwd()
+# Data directory: MarinePlasicTools/Weight
+# WorkingDir = os.getcwd()
+WorkingDir = 'Weight'
 File = 'BeachCleanGirl_Weight.txt'
 
 DATA  = np.genfromtxt(WorkingDir+os.sep+File, dtype=[('Date','datetime64[D]'),('Weight', 'float32')], delimiter ='\t', skip_header = 1)


### PR DESCRIPTION
#### Description: 

This pull request changes the `WorkingDir` variable in the `WeightPlot*py` and `WeightPlot_BCG.py` scripts to point the this repositories `Weight/` directory.  This enables these scripts to successfully run in a clone of this repository.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC